### PR TITLE
Update merge/flatten algorithm using recursive approach

### DIFF
--- a/dist/array/flatten.js
+++ b/dist/array/flatten.js
@@ -1,13 +1,9 @@
 var _flatten = function(arr) {
   var _newArr = [];
-
+  
   recursiveArr = function(_newArr) {
     return function(arr) {
-      // Go through all items in the array
       for ( var _i = 0; _i < arr.length; _i++  ) {
-        // Check if item is an Array
-        // if so call same function until no more Arrays found
-        // and push to new array
         if ( Array.isArray(arr[_i]) ) {
           recursiveArr(arr[_i]);
         }

--- a/src/array/__tests__/flaten-recursive-test.js
+++ b/src/array/__tests__/flaten-recursive-test.js
@@ -1,0 +1,10 @@
+jest.dontMock('../flatten-recursive');
+
+describe('flatten()', () => {
+  it('should flatten an array with recursive', () => {
+    var flatten = require('../flatten-recursive');
+    var unflattenedArr = [1, [2, 3, 4], 5, [6, 7]];
+
+    expect(flatten(unflattenedArr)).toEqual([1,2,3,4,5,6,7]);
+  });
+});

--- a/src/array/__tests__/flatten-test.js
+++ b/src/array/__tests__/flatten-test.js
@@ -3,8 +3,8 @@ jest.dontMock('../flatten');
 describe('flatten()', () => {
   it('should flatten an array', () => {
     var flatten = require('../flatten');
-    var unflattenedArr = [1, [2, 3, 4], 5, [6, 7]];
+    var unflattenedArr = [1,[2,[[2, 3, 4],5],6]];
 
-    expect(flatten(unflattenedArr)).toEqual([1,2,3,4,5,6,7]);
+    expect(flatten(unflattenedArr)).toEqual([1,2,3,4,5,6]);
   });
 });

--- a/src/array/flatten-recursive.js
+++ b/src/array/flatten-recursive.js
@@ -1,0 +1,20 @@
+let flatten = (arr) => {
+  let newArr = [];
+  
+  // var to not cause undefined on ES5
+  var recursiveArr = (arr) => {
+    for ( let i = 0; i < arr.length; i++  ) {
+      if ( Array.isArray(arr[i]) ) {
+        recursiveArr(arr[i]);
+      }
+      else {
+        newArr.push(arr[i]);
+      }
+    }
+  }
+
+  recursiveArr(arr);
+  return newArr;
+}
+
+module.exports = flatten;

--- a/src/array/flatten.js
+++ b/src/array/flatten.js
@@ -1,19 +1,17 @@
 let flatten = (arr) => {
   let newArr = [];
-  
-  recursiveArr = (arr) => {
-    for ( let i = 0; i < arr.length; i++  ) {
-      if ( Array.isArray(arr[i]) ) {
-        recursiveArr(arr[i]);
-      }
-      else {
-        newArr.push(arr[i]);
+  var checkArray = (item) => {
+    if (Array.isArray(item)) {
+      item.forEach(checkArray);
+    } else {
+      if (newArr.indexOf(item) === -1) {
+        newArr.push(item);
       }
     }
-  }
+  };
 
-  recursiveArr(arr);
-  return newArr;
-}
+  arr.forEach(checkArray);
+  return newArr.sort((a, b) => a - b);
+};
 
 module.exports = flatten;


### PR DESCRIPTION
Hey @pedronauck I updated the merge/flatten algorithm to recursive approach which re-use the same function to merge/flatten instead of using `forEach`. (This is asked on interviews sometimes)

The `merge/flatten` function shouldn't automatically `sort` and there's no need to check if the item is duplicated or not since it's function job is to just merge/flatten arrays nothing else.

This could be used like a method chaining e.g `flatten(arr).sort().removeDuplicate()`
