### PR TITLE
Travis and Array Flattening let error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- "0.10"

--- a/src/array/flatten.js
+++ b/src/array/flatten.js
@@ -1,7 +1,7 @@
 let flatten = (arr) => {
   let newArr = [];
 
-  let recursiveArr = (givenArr) => {
+  var recursiveArr = (givenArr) => {
     givenArr.forEach((item) => {
       (Array.isArray(item)) && (recursiveArr(item));
       (!Array.isArray(item)) && (newArr.push(item));


### PR DESCRIPTION
This PR addresses two issues:
- an error regarding let scope
- travis

Adding travis will let us improve this experiment with more features guaranteeing in PR time if the implemenetation is correct (given the tests).
Regarding let, we can't use it with recursion. This is a 'problem' that comes from a difference of `let` and `letrec` in a language like racket. See http://docs.racket-lang.org/reference/let.html
